### PR TITLE
Fix scrim inset bug in landscape shade

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/shade/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/shade/NotificationPanelViewController.java
@@ -4577,7 +4577,7 @@ public final class NotificationPanelViewController implements Dumpable {
         mDisplayTopInset = combinedInsets.top;
         mDisplayRightInset = combinedInsets.right;
         mDisplayLeftInset = combinedInsets.left;
-        mQsController.setDisplayInsets(mDisplayRightInset, mDisplayLeftInset);
+        mQsController.setDisplayInsets(mDisplayLeftInset, mDisplayRightInset);
 
         mNavigationBarBottomHeight = insets.getStableInsetBottom();
         updateMaxHeadsUpTranslation();


### PR DESCRIPTION
Left and right insets were switched in quick settings controller, leading to incorrect notification scrim layout in landscape shade. This led to the visible "flicker" described in the bug due to the launcher being visible when it shouldn't have been.

Bug: 270639123
Test: confirmed scrim appears correct in all orientations
Change-Id: If7d19d4045c8427280a9f2c4dccb635f3ae91006